### PR TITLE
Adds Dockerfile for Rpi platform

### DIFF
--- a/Dockerfile.rpi
+++ b/Dockerfile.rpi
@@ -1,0 +1,15 @@
+FROM arm32v7/node:8
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+COPY *.js /usr/src/app/
+COPY *.json /usr/src/app/
+COPY src/ /usr/src/app/src/
+
+RUN npm install && \
+    npm run build-prod && \
+    npm install --save https://github.com/MeisterTR/ioBroker.landroid-s.git
+
+EXPOSE 3000
+CMD [ "node", "dist/server.js" ]

--- a/Dockerfile.rpi
+++ b/Dockerfile.rpi
@@ -6,6 +6,7 @@ WORKDIR /usr/src/app
 COPY *.js /usr/src/app/
 COPY *.json /usr/src/app/
 COPY src/ /usr/src/app/src/
+COPY www/ /usr/src/app/www/
 
 RUN npm install && \
     npm run build-prod && \


### PR DESCRIPTION
Modified Dockerfile.rpi file that creates the docker image for the Rpi platform; published (https://hub.docker.com/r/angeloxx/landroid-bridge/) and tested.