### PR TITLE
Sample systemctl service script

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,9 @@ There is also a pre-built arm32v7 image for Raspberry Pi: ```weweave/landroid-br
     ```
     node dist/server.js
     ```
-1. Optional: Set up an init.d script to start the bridge on system startup (Linux only, see example in initd-script folder).
+1. Optional (Linux only): 
+    1. Set up an init.d script to start the bridge on system startup (see example in initd-script folder).
+    1. Set up a systemctl script to start the bridge on system startup (see example in systemctl-script folder).
 
 ### Security
 Landroid Bridge does not feature any authentication or authorization right now. If you're using MQTT to communicate with the bridge, make sure to use strong passwords to authenticate with your MQTT broker. If you're using HTTP/REST, use a proxy server like nginx or HAProxy that handles the authentication/authorization in front of the bridge.

--- a/systemctl-script/landroid-bridge.service
+++ b/systemctl-script/landroid-bridge.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Landroid Bridge
+Documentation=https://github.com/weweave/landroid-bridge
+After=network.target
+
+[Service]
+ExecStart=/usr/bin/node /home/username/landroid-bridge/dist/server.js
+WorkingDirectory=/home/username/landroid-bridge
+Restart=on-failure
+RestartSec=10
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=landroid-bridge
+User=username
+Group=username
+Environment=NODE_ENV=production PORT=3000
+
+[Install]
+WantedBy=multi-user.target

--- a/systemctl/README.md
+++ b/systemctl/README.md
@@ -1,0 +1,22 @@
+## Installation of the systemctl script
+
+This script is used in conjunction with the nodejs source installation to run as a service. 
+It is not intended for use with the docker container.
+
+Adjust the username and paths in the file, and copy it to /lib/systemd/system/
+
+```
+cp landroid-bridge /lib/systemd/system/
+```
+
+Run systemctl daemon-reload to refresh services:
+
+```
+systemctl daemon-reload
+```
+
+Enable the service
+
+```
+systemctl enable landroid-bridge.service
+```


### PR DESCRIPTION
Add sample script and instructions for configuring Linux service using systemctl, as an alternative to init.d