### PR TITLE
Add pitch, roll, yaw values from dmp field (idea from DeskApp v0.0.20).

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,9 @@ curl -X PUT -H "Content-Type: application/json" -d '{"startHour":10,"startMinute
 * landroid/status/batteryVoltage
 * landroid/status/batteryTemperature
 * landroid/status/batteryLevel
+* landroid/status/pitch
+* landroid/status/roll
+* landroid/status/yaw
 * landroid/status/errorCode
 * landroid/status/errorDescription: 
 * landroid/status/statusCode

--- a/src/LandroidDataset.ts
+++ b/src/LandroidDataset.ts
@@ -18,6 +18,9 @@ export class LandroidDataset {
     batteryVoltage: number;
     batteryTemperature: number;
     batteryLevel: number;
+    pitch: number;
+    roll: number;
+    yaw: number;
     errorCode: number;
     errorDescription: string;
     statusCode: number;
@@ -49,6 +52,9 @@ export class LandroidDataset {
             batteryVoltage: this.batteryVoltage,
             batteryTemperature: this.batteryTemperature,
             batteryLevel: this.batteryLevel,
+            pitch: this.pitch,
+            roll: this.roll,
+            yaw: this.yaw,
             errorCode: this.errorCode,
             errorDescription: this.errorDescription,
             statusCode: this.statusCode,
@@ -101,6 +107,11 @@ export class LandroidDataset {
             this.statusDescription = LandroidDataset.STATUS_CODES[this.statusCode];
             this.errorCode = Number(readings["dat"]["le"]).valueOf();
             this.errorDescription = LandroidDataset.ERROR_CODES[this.errorCode];
+            if (readings["dat"]["dmp"]) {
+                this.pitch = Number(readings["dat"]["dmp"][0]).valueOf();
+                this.roll  = Number(readings["dat"]["dmp"][1]).valueOf();
+                this.yaw   = Number(readings["dat"]["dmp"][2]).valueOf();
+            }
         }
     }
 


### PR DESCRIPTION
In the [desktop app](https://www.roboter-forum.com/index.php?thread/22795-entwicklungsprojekt-worx-landroid-kress-mission-desktop-app/&pageNo=1) I noted, that it is possible to read out the axes (pitch, roll, yaw).  I found out, that these seem to be transferred in the dat:dmp array.
This patch makes these three axes (pitch, roll, yaw) available via MQTT.