### PR TITLE
Dashboard resources missing in Docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,5 +25,6 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
         org.label-schema.vcs-url="https://github.com/virtualzone/landroid-bridge" \
         org.label-schema.schema-version="1.0"
 COPY --from=build /usr/src/app/dist ./dist
+COPY www/ ./www/
 EXPOSE 3000
 CMD [ "node", "dist/server.js" ]

--- a/Dockerfile.arm32v6
+++ b/Dockerfile.arm32v6
@@ -31,5 +31,6 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
         org.label-schema.vcs-url="https://github.com/virtualzone/landroid-bridge" \
         org.label-schema.schema-version="1.0"
 COPY --from=build /usr/src/app/dist ./dist
+COPY www/ ./www/
 EXPOSE 3000
 CMD [ "node", "dist/server.js" ]

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -31,5 +31,6 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
         org.label-schema.vcs-url="https://github.com/virtualzone/landroid-bridge" \
         org.label-schema.schema-version="1.0"
 COPY --from=build /usr/src/app/dist ./dist
+COPY www/ ./www/
 EXPOSE 3000
 CMD [ "node", "dist/server.js" ]

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -31,5 +31,6 @@ LABEL org.label-schema.build-date=$BUILD_DATE \
         org.label-schema.vcs-url="https://github.com/virtualzone/landroid-bridge" \
         org.label-schema.schema-version="1.0"
 COPY --from=build /usr/src/app/dist ./dist
+COPY www/ ./www/
 EXPOSE 3000
 CMD [ "node", "dist/server.js" ]

--- a/Dockerfile.nativeARM
+++ b/Dockerfile.nativeARM
@@ -30,6 +30,7 @@ FROM prod as final
 RUN apk del build-dependencies
 
 COPY --from=build /usr/src/app/dist ./dist
+COPY www/ ./www/
 
 EXPOSE 3000
 CMD [ "node", "dist/server.js" ]


### PR DESCRIPTION
The current Docker images are missing the www folder, so the dashboard isn't working. 

This change adds the www resources back into the final image.